### PR TITLE
Allow command line arguments for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project offers Ada bindings for the C librdkafka library. You can use it to send and receive from a Kafka bus from Ada. Currently work in progress, it does not offer all functionalities of librdkafka yet. If what you are looking for is simply producing data onto a kafka bus or consuming data, this library likely already supports the features you need.
 
 Supported functionalities:
+
 - Basic error handling
 - Kafka handle creation and destruction
 - Topic handling
@@ -13,6 +14,7 @@ Supported functionalities:
 - Topic configuration
 
 Not yet supported:
+
 - Retrieving debug contexts
 - Advanced error handling (Description, fatal errors, retriable errors etc.)
 - Partition handling
@@ -31,7 +33,7 @@ Not yet supported:
 
 If you need some of those not supported features, feel free to open a pull request.
 
-## Building and installing from source 
+## Building and installing from source
 
 To install this library on your system, run the following command:
 
@@ -44,7 +46,7 @@ Note: You need to have librdkafka already installed.
 
 ## Usage
 
-See the `examples/` folder for code examples showcasing a basic consumer and a 
+See the `examples/` folder for code examples showcasing a basic consumer and a
 basic producer using Kafka Ada.
 
 ## Latence Technologies

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Note: You need to have librdkafka already installed.
 See the `examples/` folder for code examples showcasing a basic consumer and a
 basic producer using Kafka Ada.
 
+You can use the `-t` (or `--topic`) argument to change the name of the Kafka Topic when using either example.
+
 ## Latence Technologies
 
 This Ada binding is offered by LatenceTech, a Montreal based startup specialized in low-latency optimization. Our website is https://latencetech.com/

--- a/examples/getcommandargument.adb
+++ b/examples/getcommandargument.adb
@@ -1,0 +1,24 @@
+with GNAT.Command_Line; use GNAT.Command_Line;
+with GNAT.Strings;
+
+package body GetCommandArgument is
+
+function Parse_Command_Line (DefaultValue : in String) return String is
+    VAR : aliased GNAT.Strings.String_Access;
+    Cmd_Line_Setup : Command_Line_Configuration;
+  begin
+    Define_Switch(Config      => Cmd_Line_Setup,
+                  Output      => VAR'Access,
+                  Switch      => Switch_Arg,
+                  Long_Switch => Long_Switch_Arg,
+                  Help        => Help_Text);
+    Getopt(Cmd_Line_Setup);
+    GNAT.Command_Line.Free(Cmd_Line_Setup);
+    return (if VAR.all = "" then DefaultValue else VAR.all);
+    exception
+      when Exit_From_Command_Line =>
+        GNAT.Command_Line.Free(Cmd_Line_Setup);
+        raise Exit_From_Command_Line;
+  end;
+
+end GetCommandArgument;

--- a/examples/getcommandargument.ads
+++ b/examples/getcommandargument.ads
@@ -1,0 +1,10 @@
+generic
+  Switch_Arg     : in String;  -- ex: "-t:"
+  Long_Switch_Arg: in String;  -- ex: "--topic:"
+  Help_Text      : in String;  -- ex: "Topic name to use"
+
+package GetCommandArgument is
+
+  function Parse_Command_Line (DefaultValue : in String) return String;
+
+end GetCommandArgument;

--- a/examples/simple_consumer.adb
+++ b/examples/simple_consumer.adb
@@ -9,6 +9,7 @@ with Kafka.Message;
 with Kafka.Topic;
 with Kafka.Topic.Partition;
 with Signal;
+with GetCommandArgument;
 with System;
 
 --
@@ -22,6 +23,7 @@ procedure Simple_Consumer is
     Handle : Kafka.Handle_Type;
     
     Handler : Signal.Handler; -- basic Signal handler to stop on CTRL + C
+    package KafkaTopic is new GetCommandArgument ("-t:", "--topic:", "Topic name to use");
 begin
 	-- Create configuration
     Config := Kafka.Config.Create;
@@ -41,7 +43,8 @@ begin
         Partition_List : Kafka.Partition_List_Type;
     begin
         Partition_List := Kafka.Topic.Partition.Create_List(1);
-        Kafka.Topic.Partition.List_Add(Partition_List, "test_topic", Kafka.RD_KAFKA_PARTITION_UA);
+        Kafka.Topic.Partition.List_Add(Partition_List,
+            KafkaTopic.Parse_Command_Line("test_topic"), Kafka.RD_KAFKA_PARTITION_UA);
         
         Kafka.Subscribe(Handle, Partition_List);
         Kafka.Topic.Partition.Destroy_List(Partition_List);

--- a/examples/simple_producer.adb
+++ b/examples/simple_producer.adb
@@ -5,6 +5,7 @@ with Kafka;
 with Kafka.Config;
 with Kafka.Topic;
 with System;
+with GetCommandArgument;
 
 --
 -- Basic Kafka producer
@@ -13,6 +14,8 @@ procedure Simple_Producer is
     Config : Kafka.Config_Type;
     Handle : Kafka.Handle_Type;
     Topic  : Kafka.Topic_Type;
+
+    package CommandTopic is new GetCommandArgument ("-t:", "--topic:", "Topic name to use");
 begin
     Ada.Text_IO.Put_Line("Kafka version: " & Kafka.Version);
 
@@ -27,7 +30,8 @@ begin
     Handle := Kafka.Create_Handle(Kafka.RD_KAFKA_PRODUCER, Config);
 
     -- Create topic handle
-    Topic := Kafka.Topic.Create_Topic_Handle(Handle, "test_topic"); -- topic must already exist
+    Topic := Kafka.Topic.Create_Topic_Handle(Handle,
+        CommandTopic.Parse_Command_Line("test_topic")); -- topic must already exist
 
     -- Producing a String
     Kafka.Produce(Topic,


### PR DESCRIPTION
Adds a new library so that usage examples may use the `-t` (or `-topic`) argument to modify the topic used in the code.

This allows the topic to be modified without recompiling the project.
This change adds this feature without making it mandatory, so the default behavior is unchanged.